### PR TITLE
Add a environment variable for led strip type

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ For supported GPIOs please see [rpi-ws281x-python](https://github.com/rpi-ws281x
 | `LED_DMA_NUM` | optional | 10 | 0-14 |
 | `LED_BRIGHTNESS` | optional | 255 | 1-255 |
 | `LED_INVERT` | optional | 0 | 0 or 1 |
+| `LED_STRIP_TYPE` | optional | GRB | BGR, BRG, GBR, GRB, RBG, RGB |
 | `MQTT_BROKER` | optional | 'localhost' | |
 | `MQTT_USER` | optional | None | |
 | `MQTT_PASSWORD` | optional | None | |

--- a/ws281x.py
+++ b/ws281x.py
@@ -6,7 +6,7 @@ import os
 import paho.mqtt.client as paho
 import time
 from rpi_ws281x import Color
-from rpi_ws281x import Adafruit_NeoPixel
+from rpi_ws281x import Adafruit_NeoPixel, ws
 from effects.utils.utils import *
 
 from effects.theater_chase_rainbow import effect_theater_chase_rainbow
@@ -21,6 +21,7 @@ LED_FREQ_HZ = os.getenv('LED_FREQ_HZ', 800000)
 LED_DMA_NUM = os.getenv('LED_DMA_NUM', 10)
 LED_BRIGHTNESS = os.getenv('LED_BRIGHTNESS', 255)
 LED_INVERT = os.getenv('LED_INVERT', 0)
+LED_STRIP_TYPE = os.getenv('LED_STRIP_TYPE', 'GRB').upper()
 
 MQTT_BROKER = os.getenv('MQTT_BROKER', 'localhost')
 MQTT_USER = os.getenv('MQTT_USER', None)
@@ -65,6 +66,15 @@ effects_list = {
     }
 }
 
+strip_type_by_name = {
+    "BGR": ws.WS2811_STRIP_BGR,
+    "BRG": ws.WS2811_STRIP_BRG,
+    "GBR": ws.WS2811_STRIP_GBR,
+    "GRB": ws.WS2811_STRIP_GRB,
+    "RBG": ws.WS2811_STRIP_RBG,
+    "RGB": ws.WS2811_STRIP_RGB,
+}
+
 # error checking
 LED_CHANNEL = int(LED_CHANNEL)
 LED_COUNT = int(LED_COUNT)
@@ -73,6 +83,7 @@ LED_DMA_NUM = int(LED_DMA_NUM)
 LED_GPIO = int(LED_GPIO)
 LED_BRIGHTNESS = int(LED_BRIGHTNESS)
 LED_INVERT = int(LED_INVERT)
+LED_STRIP_TYPE = strip_type_by_name.get(LED_STRIP_TYPE)
 
 if LED_COUNT is None:
     raise ValueError('LED_COUNT is required env parameter')
@@ -88,6 +99,9 @@ if LED_FREQ_HZ != 800000 and LED_FREQ_HZ != 400000:
 
 if LED_DMA_NUM > 14 or LED_DMA_NUM < 0:
     raise ValueError('LED_DMA_NUM must be between 0-14')
+
+if LED_STRIP_TYPE is None:
+    raise ValueError('LED_STRIP_TYPE must be one of %s', ', '.join(strip_type_by_name.keys()))
 
 
 def effect_list_string():
@@ -280,6 +294,7 @@ strip = Adafruit_NeoPixel(
     LED_INVERT,
     LED_BRIGHTNESS,
     LED_CHANNEL,
+    LED_STRIP_TYPE
 )
 
 # Intialize the library (must be called once before other functions).


### PR DESCRIPTION
This improves support for led strips which have the LED's wired up in a different ordering. 