### PR TITLE
Remove 'white_value' from discovery data

### DIFF
--- a/ws281x.py
+++ b/ws281x.py
@@ -252,7 +252,6 @@ def on_mqtt_connect(mqtt, userdata, flags, rc):
             'qos': MQTT_QOS,
             'brightness': True,
             'rgb': True,
-            'white_value': False,
             'color_temp': False,
             'effect': True,
             'effect_list': effect_list_string(),


### PR DESCRIPTION
Otherwise Home Assistant will fail to discover the device via MQTT, with the following error: "The 'white_value' option has been removed, please remove it from your configuration"

https://developers.home-assistant.io/blog/2022/08/18/light_white_value_removed/